### PR TITLE
docs(readme): remove deprecated --setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ pip install -U "cocoindex[embeddings]"
 Update index:
 
 ```bash
-cocoindex update --setup main.py
+cocoindex update main.py
 ```
 
 Run query:


### PR DESCRIPTION
Just remove deprecated `--setup` ☺️

```sh
  --setup      (DEPRECATED) Automatically setup backends for the flow if it's
               not setup yet. This is now the default behavior.  [default:
               True]
```
