### PR TITLE
fix: change document language to markdown when transform

### DIFF
--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ def text_embedding_flow(
         # Split the document into chunks, put into `chunks` field
         doc["chunks"] = doc["content"].transform(
             cocoindex.functions.SplitRecursively(),
-            language="javascript",
+            language="markdown",
             chunk_size=300,
             chunk_overlap=100,
         )


### PR DESCRIPTION
The data in the demo is markdown currently, so change document language to markdown when transform